### PR TITLE
Milestone 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.0.0 (Soon)
+
+* Add PhpUnit tests for class Html and MarkDown ([a4890bc](https://github.com/DigiLive/gitChangelog/commit/a4890bc))
+* Add code coverage tags ([7ce91b8](https://github.com/DigiLive/gitChangelog/commit/7ce91b8))
+* Add formatting of issues ids & hashes to hyperlink ([10816fb](https://github.com/DigiLive/gitChangelog/commit/10816fb))
+* Add issue templates ([5bbf5ef](https://github.com/DigiLive/gitChangelog/commit/5bbf5ef), [6d34e1c](https://github.com/DigiLive/gitChangelog/commit/6d34e1c))
+* Add setting base content by value or file content. ([93ca694](https://github.com/DigiLive/gitChangelog/commit/93ca694))
+* Fix [#7](https://github.com/DigiLive/gitChangelog/issues/7), Fix [#8](https://github.com/DigiLive/gitChangelog/issues/8) ([d4e352e](https://github.com/DigiLive/gitChangelog/commit/d4e352e))
+* Fix PhpUnit tests for GitChangelog ([b62ded6](https://github.com/DigiLive/gitChangelog/commit/b62ded6))
+* Fix docBlock of GitChangelog::$labels ([1fea85e](https://github.com/DigiLive/gitChangelog/commit/1fea85e))
+* Fix html renderer ([c66b572](https://github.com/DigiLive/gitChangelog/commit/c66b572))
+* Fix markdown renderer ([ab29669](https://github.com/DigiLive/gitChangelog/commit/ab29669))
+* Optimize Git execution and Fix docBlocks ([fc79a58](https://github.com/DigiLive/gitChangelog/commit/fc79a58))
+
 ## v0.4.0 (2020-10-28)
 
 * Add separate renderers for GitChangelog ([2df97ee](https://github.com/DigiLive/gitChangelog/commit/2df97ee))

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ new [issue](https://github.com/DigiLive/gitChangelog/issues/new) if your concern
 
 - Choose from different renderers or create your own.
 - List Tags and their date.
-- List unique commit subjects per tag/release.
-- List commit hashes per unique subject (optional).
-- Include commit subjects (and hashes) of the HEAD revision (E.g. Unreleased changes).
+- List unique commit titles per tag/release.
+- List commit hashes per unique title (optional).
+- Include commit titles (and hashes) of the HEAD revision (E.g. Unreleased changes).
 - Append the content of another file (E.g. An already existing changelog).
 - Save the content of the (appended) changelog to file.
 
@@ -31,23 +31,23 @@ new [issue](https://github.com/DigiLive/gitChangelog/issues/new) if your concern
 
 - Set path to generate a changelog another local repository.
 - Set a From- and To tag to limit the changelog.
-- Filter subjects by labels<sup>1</sup>.
+- Filter titles by labels<sup>1</sup>.
 - Set a header for the changelog (E.g. a title).
-- Set a custom subject for the HEAD revision.
+- Set a custom title for the HEAD revision.
 - Set a custom date for the HEAD revision (E.g. Next Tag/Release date).
 - Set a custom message to indicate there are no commits present.
 - In- or exclude merge commits.
 - Set an ordering key for sorting tags/releases<sup>2</sup>.
 - Set the sort order of tags/releases.
-- Set the sort order of subjects.
+- Set the sort order of titles.
 
-1. A label is considered to be the first word of a commit subject.
+1. A label is considered to be the first word of a commit title.
 2. Using an invalid key will result in unlisted changes or when enabled, just the changes of the HEAD revision.
 
 #### Markdown Renderer
 
 - Define a custom format for Tag/Release lines.
-- Define a custom format for subject lines.
+- Define a custom format for title lines.
 - Define a custom format for singe hashes.
 - Define a custom format for hash lines.
 
@@ -100,13 +100,13 @@ try {
 
 In order to suitable a good changelog, you should follow the following guidelines:
 
-- Commit messages must have a subject line and may have body copy. These must be separated by a blank line.
+- Commit messages must have a title line and may have body copy. These must be separated by a blank line.
 
-- The subject line must not exceed 50 characters.
+- The title line must not exceed 50 characters.
 
-- The subject line should be capitalized and must not end in a period.
+- The title line should be capitalized and must not end in a period.
 
-- The subject line must be written in an imperative mood (Fix, not Fixed / Fixes etc.).
+- The title line must be written in an imperative mood (Fix, not Fixed / Fixes etc.).
 
 - The body copy must be wrapped at 72 columns.
 

--- a/README.md
+++ b/README.md
@@ -6,109 +6,127 @@
 
 Generate a changelog from git commits of the local repository.
 
-This library parses information which is stored in the Git directory in which it is currently located. With this
-information, it generates a changelog which can be saved into a file.
+This library parses information which is stored in a Git repository. With this
+information, it generates a changelog which can be saved to a file. The
+information is extracted from the branch which is currently checked out.
 
-Check out this [example](CHANGELOG.md) which is actually the changelog of this repository.
+Take a look at this [example](CHANGELOG.md). It is the changelog of the
+GitChangelog repository, build by this library.
 
-If you have any questions, comments or ideas concerning this library, Please consult
-the [Wiki](https://github.com/DigiLive/gitChangelog/wiki) at first. Create a
-new [issue](https://github.com/DigiLive/gitChangelog/issues/new) if your concerns remain unanswered.
+If you have any questions, comments or ideas concerning this library, Please
+consult the [Wiki](https://github.com/DigiLive/gitChangelog/wiki) at first.
+Create a new [issue](https://github.com/DigiLive/gitChangelog/issues/new) if
+your concerns remain unanswered.
 
 ## Features
 
 ### Main
 
-- Choose from different renderers or create your own.
-- List Tags and their date.
-- List unique commit titles per tag/release.
-- List commit hashes per unique title (optional).
-- Include commit titles (and hashes) of the HEAD revision (E.g. Unreleased changes).
-- Append the content of another file (E.g. An already existing changelog).
-- Save the content of the (appended) changelog to file.
+* Markdown and Html renderers included.
+
+* Choose included renderers or create your own.
+
+* List Tags and their date.
+
+* List unique commit titles per tag/release.
+
+* List commit hashes per unique title (optional).
+
+* Include commit titles (and hashes) of the HEAD revision (E.g. Unreleased
+  changes).
+
+* Append other content (E.g. An already existing changelog).
+
+* Save the content of the (appended) changelog to file.
 
 ### Other
 
-- Set path to generate a changelog another local repository.
-- Set a From- and To tag to limit the changelog.
-- Filter titles by labels<sup>1</sup>.
-- Set a header for the changelog (E.g. a title).
-- Set a custom title for the HEAD revision.
-- Set a custom date for the HEAD revision (E.g. Next Tag/Release date).
-- Set a custom message to indicate there are no commits present.
-- In- or exclude merge commits.
-- Set an ordering key for sorting tags/releases<sup>2</sup>.
-- Set the sort order of tags/releases.
-- Set the sort order of titles.
+* Set path to generate a changelog of another local repository.
+* Set a tag range to limit the changelog.
+* Filter titles by labels<sup>1</sup>.
+* Set a title for the changelog (E.g. a header).
+* Set a custom title for the HEAD revision (E.g. Next release version).
+* Set a custom date for the HEAD revision (E.g. Next release date).
+* Set a custom message to indicate there are no commits present.
+* In- or exclude merge commits.
+* Set an ordering key for sorting tags/releases<sup>2</sup>.
+* Set the sort order of tags/releases.
+* Set the sort order of titles.
 
 1. A label is considered to be the first word of a commit title.
-2. Using an invalid key will result in unlisted changes or when enabled, just the changes of the HEAD revision.
+
+2. Using an invalid key will result in unlisted changes or when enabled, just
+   the changes of the HEAD revision.
 
 #### Markdown Renderer
 
-- Define a custom format for Tag/Release lines.
-- Define a custom format for title lines.
-- Define a custom format for singe hashes.
-- Define a custom format for hash lines.
+* Define a custom format for Tag/Release lines.
+* Define a custom format for title lines.
+* Format hashes into links to commit view of the remote repository.
+* Format issues into links to Issue tracker of the repository.
 
 #### Html Renderer
 
-- Define a custom format for singe hashes.
+* Format hashes into links to commit view of the remote repository.
+* Format issues into links to Issue tracker of the repository.
 
 ## Installation
 
-The preferred method is to install the library with [Composer](http://getcomposer.org).
+The preferred method is to install the library
+with [Composer](http://getcomposer.org).
 
 ```sh
 > composer require digilive/git-changelog:^1
 ```
 
-Alternatively you can download the latest release from [Github](https://github.com/DigiLive/gitChangelog/releases).
+Set the version constraint to a value which suits you best.  
+Alternatively you can download the latest release
+from [Github](https://github.com/DigiLive/gitChangelog/releases).
 
-## Example use
+## Minimal Example use
 
 ```php
 <?php
 
 use DigiLive\GitChangelog\Renderers\MarkDown;
-
-// Instantiate composer's auto loader.
-require 'Path/To/vendor/autoload.php';
+ 
+// Use composer's auto loader.
+$requiredFile = 'Path/To/vendor/autoload.php';
 
 // Or include the library manually.
-// require_once 'Path/To/MarkDown.php';
+// $requiredFile = 'Path/To/MarkDown.php';
 
-$markDownLog = new MarkDown();
+require_once $requiredFile;
 
-// Generate and save.
-try {
-    $markDownLog->build();
-    $markDownLog->save('CHANGELOG.md');
-} catch (Exception $e) {
-    exit($e);
-}
+// Instantiate the library's renderer.
+$changelog = new MarkDown();
+// Build and save the changelog with all defaults.
+$changelog->build();
+$changelog->save('CHANGELOG.md');
 ```
 
 ## Notes
 
-- Some settings can be changed directly by setting a public property.
+* Some options can be changed directly by setting a public property.
   **(Setting a value of an invalid type, might result in unexpected results.)**
 
-- Others have to be set by calling a method.
+* Others have to be set by calling a method.
 
 ## Commit guidelines
 
-In order to suitable a good changelog, you should follow the following guidelines:
+In order to create a good changelog, you should follow the following guidelines:
 
-- Commit messages must have a title line and may have body copy. These must be separated by a blank line.
+* Commit messages **must** have a title line and may have body copy. These must
+  be separated by a blank line.
 
-- The title line must not exceed 50 characters.
+* The title line **must not** exceed 50 characters.
 
-- The title line should be capitalized and must not end in a period.
+* The title line should be capitalized and **must not** end in a period.
 
-- The title line must be written in an imperative mood (Fix, not Fixed / Fixes etc.).
+* The title line **must** be written in an imperative mood (Fix, not Fixed /
+  Fixes etc.).
 
-- The body copy must be wrapped at 72 columns.
+* The body copy **must** be wrapped at 72 columns.
 
-- The body copy must only contain explanations as to what and why, never how. The latter belongs in documentation and
-  implementation.
+* The body copy **must** only contain explanations as to what and why, never
+  how. The latter belongs in documentation and implementation.

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -119,7 +119,7 @@ class GitChangelog
         'includeMergeCommits' => false,
         'tagOrderBy'          => 'creatordate',
         'tagOrderDesc'        => true,
-        'commitOrder'         => 'ASC',
+        'commitOrder'         => 'ASC', //TODO: Refactor to 'subjectOrder'
     ];
     /**
      * @var string Value of the oldest tag to include into the generated changelog. If the value is null it refers to
@@ -196,7 +196,9 @@ class GitChangelog
         $commandResult = 1;
         exec("git $gitPath tag --sort=-{$this->options['tagOrderBy']}", $this->gitTags, $commandResult);
         if ($commandResult !== 0) {
+            // @codeCoverageIgnoreStart
             throw new RuntimeException('An error occurred while fetching the tags from the repository!');
+            // @codeCoverageIgnoreEnd
         }
 
         // Add HEAD revision as tag.
@@ -277,7 +279,9 @@ class GitChangelog
         }
 
         if (array_sum($commandResults)) {
+            // @codeCoverageIgnoreStart
             throw new RuntimeException('An error occurred while fetching the commit data from the repository.');
+            // @codeCoverageIgnoreEnd
         }
 
         // Cache commit data and process it.

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -73,8 +73,6 @@ use RuntimeException;
  *
  * Title lines must never contain (and / or start with) anything else.
  *
- * @todo    Change property baseFile to baseContent, see local wiki.
- *
  * @package DigiLive\GitChangelog
  */
 class GitChangelog
@@ -360,8 +358,6 @@ class GitChangelog
      * Get the content of the generated changelog.
      *
      * Optionally the generated changelog is appended with the content of property GitChangelog::$baseContent.
-     * If this property's value resolves to a valid filepath, the contents of this file is used as base content.
-     * Otherwise the value is considered to be the base content.
      *
      * @SuppressWarnings(PHPMD.ErrorControlOperator)
      *

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -142,8 +142,8 @@ class GitChangelog
      */
     private $gitTags;
     /**
-     * @var string[] Contains the labels to filter the commit titles. All titles which do not start with any of
-     *               these labels will not be listed. To disable this filtering, remove all labels from this variable.
+     * @var string[] Contains the labels to filter the commit titles. Only titles which start with any of these labels
+     *               will be listed. To disable this filtering, remove all labels from this property.
      */
     private $labels = [
 //        'Add',          // Create a capability e.g. feature, test, dependency.

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -73,6 +73,9 @@ use RuntimeException;
  *
  * Subject lines must never contain (and / or start with) anything else.
  *
+ * @todo    Change property baseFile to baseContent, see local wiki.
+ * @todo    Refactor subject to title.
+ *
  * @package DigiLive\GitChangelog
  */
 class GitChangelog
@@ -100,7 +103,7 @@ class GitChangelog
      *  <pre>
      *  logHeader           First string of the generated changelog.
      *  headTagName         Name of the HEAD revision (Implies unreleased commits).
-     *  headTagDate         Date of head subject (Implies date of next release).
+     *  headTagDate         Date of head revision (Implies date of next release).
      *  noChangesMessage    Message to show when there are no commit subjects to list for a tag.
      *  addHashes           True includes commit hashes to the listed subjects.
      *  includeMergeCommits True includes merge commits in the subject lists.
@@ -119,7 +122,7 @@ class GitChangelog
         'includeMergeCommits' => false,
         'tagOrderBy'          => 'creatordate',
         'tagOrderDesc'        => true,
-        'subjectOrder'         => 'ASC',
+        'subjectOrder'        => 'ASC',
     ];
     /**
      * @var string Value of the oldest tag to include into the generated changelog. If the value is null it refers to
@@ -226,8 +229,8 @@ class GitChangelog
      * [
      *     Tag => [
      *         'date'           => string,
-     *         'uniqueSubjects' => [],
-     *         'hashes'         => []
+     *         'uniqueSubjects' => string[],
+     *         'hashes'         => string[]
      * ]
      *
      * Note:
@@ -395,7 +398,7 @@ class GitChangelog
      *
      * @throws InvalidArgumentException When the tag does not exits in the repository.
      */
-    public function setToTag($tag = null)
+    public function setToTag($tag = null): void
     {
         $tag = $tag ?? '';
         Utilities::arraySearch($tag, $this->gitTags);
@@ -411,7 +414,7 @@ class GitChangelog
      *
      * @throws InvalidArgumentException When the tag does not exits in the repository.
      */
-    public function setFromTag($tag = null)
+    public function setFromTag($tag = null): void
     {
         if ($tag !== null) {
             Utilities::arraySearch($tag, $this->gitTags);
@@ -447,7 +450,7 @@ class GitChangelog
     /**
      * Set filter labels.
      *
-     * This method clear the existing labels and adds the parameter values as the new labels.
+     * This method clears the existing labels and adds the parameter values as the new labels.
      *
      * Declare a value as parameter for each label you want to set.
      * You can also pass an array of labels, using the splat operator.
@@ -461,7 +464,7 @@ class GitChangelog
      *
      * @see GitChangelog::processCommitData()
      */
-    public function setLabels(...$labels)
+    public function setLabels(...$labels): void
     {
         $this->labels = [];
         $this->addLabel(...$labels);
@@ -506,7 +509,7 @@ class GitChangelog
      * @throws InvalidArgumentException When setting option 'headTag' to an invalid value.
      * @see GitChangelog::$options
      */
-    public function setOptions($name, $value = null)
+    public function setOptions($name, $value = null): void
     {
         if (!is_array($name)) {
             $name = [$name => $value];

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -106,7 +106,7 @@ class GitChangelog
      *  includeMergeCommits True includes merge commits in the subject lists.
      *  tagOrderBy          Specify on which field the fetched tags have to be ordered.
      *  tagOrderDesc        True to sort the tags in descending order.
-     *  commitOrder         Set to 'ASC' or 'DESC' to sort the subjects in resp. ascending/descending order.
+     *  subjectOrder        Set to 'ASC' or 'DESC' to sort the subjects in resp. ascending/descending order.
      *  </pre>
      * @see https://git-scm.com/docs/git-for-each-ref
      */
@@ -119,7 +119,7 @@ class GitChangelog
         'includeMergeCommits' => false,
         'tagOrderBy'          => 'creatordate',
         'tagOrderDesc'        => true,
-        'commitOrder'         => 'ASC', //TODO: Refactor to 'subjectOrder'
+        'subjectOrder'         => 'ASC',
     ];
     /**
      * @var string Value of the oldest tag to include into the generated changelog. If the value is null it refers to

--- a/src/Renderers/Html.php
+++ b/src/Renderers/Html.php
@@ -52,7 +52,7 @@ class Html extends GitChangelog implements RendererInterface
     /**
      * @var string Url to commit view of the remote repository. If set, hashes of commit subjects are converted into
      *             links which refer to the corresponding commit at the remote.
-     *             {hash} is replaced by the issue number.
+     *             {hash} is replaced by the commits hash id.
      */
     public $commitUrl;
     /**

--- a/src/Renderers/Html.php
+++ b/src/Renderers/Html.php
@@ -77,9 +77,9 @@ class Html extends GitChangelog implements RendererInterface
 
         foreach ($commitData as $tag => $data) {
             // Add tag header and date.
-            if ($tag == 'HEAD') {
-                $tag          = $this->options['headSubject'];
-                $data['date'] = $this->options['nextTagDate'];
+            if ($tag === '') {
+                $tag          = $this->options['headTagName'];
+                $data['date'] = $this->options['headTagDate'];
             }
 
             $logContent .= "<h2>$tag ({$data['date']})</h2><ul>";

--- a/src/Renderers/Html.php
+++ b/src/Renderers/Html.php
@@ -101,7 +101,7 @@ class Html extends GitChangelog implements RendererInterface
             }
 
             // Sort commit subjects.
-            Utilities::natSort($data['subjects'], $this->options['commitOrder']);
+            Utilities::natSort($data['subjects'], $this->options['subjectOrder']);
 
             // Add commit subjects.
             foreach ($data['subjects'] as $subjectKey => $subject) {

--- a/src/Renderers/Html.php
+++ b/src/Renderers/Html.php
@@ -76,7 +76,9 @@ class Html extends GitChangelog implements RendererInterface
         $commitData = $this->fetchCommitData();
 
         if (!$commitData) {
-            $this->changelog = "<p>$logContent{$this->options['noChangesMessage']}</p>";
+            $this->changelog = "$logContent<p>{$this->options['noChangesMessage']}</p>";
+
+            return;
         }
 
         if (!$this->options['tagOrderDesc']) {
@@ -103,12 +105,14 @@ class Html extends GitChangelog implements RendererInterface
 
             // Add commit subjects.
             foreach ($data['subjects'] as $subjectKey => $subject) {
-                $subject    = preg_replace(
-                    '/#([0-9]+)/',
-                    '<a href="' . str_replace('{issue}', '$1', $this->issueUrl) . '">' . '$0' . '</a>',
-                    $subject
-                );
-                $logContent .= "<li>$subject (" . $this->formatHashes($data['hashes'][$subjectKey]) . ")</li>";
+                if ($this->issueUrl !== null) {
+                    $subject = preg_replace(
+                        '/#([0-9]+)/',
+                        '<a href="' . str_replace('{issue}', '$1', $this->issueUrl) . '">$0</a>',
+                        $subject
+                    );
+                }
+                $logContent .= "<li>$subject " . $this->formatHashes($data['hashes'][$subjectKey]) . '</li>';
             }
 
             $logContent .= '</ul>';
@@ -134,11 +138,13 @@ class Html extends GitChangelog implements RendererInterface
             return '';
         }
 
-        foreach ($hashes as &$hash) {
-            $hash = '<a href="' . str_replace('{hash}', $hash, $this->commitUrl) . "\">$hash</a>";
+        if ($this->commitUrl !== null) {
+            foreach ($hashes as &$hash) {
+                $hash = '<a href="' . str_replace('{hash}', $hash, $this->commitUrl) . "\">$hash</a>";
+            }
+            unset($hash);
         }
-        unset($hash);
 
-        return implode(', ', $hashes);
+        return '(' . implode(', ', $hashes) . ')';
     }
 }

--- a/src/Renderers/Html.php
+++ b/src/Renderers/Html.php
@@ -50,13 +50,13 @@ use Exception;
 class Html extends GitChangelog implements RendererInterface
 {
     /**
-     * @var string Url to commit view of the remote repository. If set, hashes of commit subjects are converted into
+     * @var string Url to commit view of the remote repository. If set, hashes of commit titles are converted into
      *             links which refer to the corresponding commit at the remote.
      *             {hash} is replaced by the commits hash id.
      */
     public $commitUrl;
     /**
-     * @var string Url to Issue tracker of the repository. If set, issue references in commit subject are converted into
+     * @var string Url to Issue tracker of the repository. If set, issue references in commit title are converted into
      *             links which refer to the corresponding issue at the tracker.
      *             {issue} is replaced by the issue number.
      */
@@ -94,25 +94,25 @@ class Html extends GitChangelog implements RendererInterface
 
             $logContent .= "<h2>$tag ({$data['date']})</h2><ul>";
 
-            // No subjects present for this tag.
-            if (!$data['subjects']) {
+            // No titles present for this tag.
+            if (!$data['titles']) {
                 $logContent .= "<li>{$this->options['noChangesMessage']}</li></ul>";
                 continue;
             }
 
-            // Sort commit subjects.
-            Utilities::natSort($data['subjects'], $this->options['subjectOrder']);
+            // Sort commit titles.
+            Utilities::natSort($data['titles'], $this->options['titleOrder']);
 
-            // Add commit subjects.
-            foreach ($data['subjects'] as $subjectKey => $subject) {
+            // Add commit titles.
+            foreach ($data['titles'] as $titleKey => $title) {
                 if ($this->issueUrl !== null) {
-                    $subject = preg_replace(
+                    $title = preg_replace(
                         '/#([0-9]+)/',
                         '<a href="' . str_replace('{issue}', '$1', $this->issueUrl) . '">$0</a>',
-                        $subject
+                        $title
                     );
                 }
-                $logContent .= "<li>$subject " . $this->formatHashes($data['hashes'][$subjectKey]) . '</li>';
+                $logContent .= "<li>$title " . $this->formatHashes($data['hashes'][$titleKey]) . '</li>';
             }
 
             $logContent .= '</ul>';
@@ -122,7 +122,7 @@ class Html extends GitChangelog implements RendererInterface
     }
 
     /**
-     * Format the hashes of a commit subject into a string.
+     * Format the hashes of a commit title into a string.
      *
      * Each hash is formatted into a link as defined by property commitUrl.
      * After formatting, all hashes are concatenated to a single line, comma separated.

--- a/src/Renderers/MarkDown.php
+++ b/src/Renderers/MarkDown.php
@@ -93,8 +93,8 @@ class MarkDown extends GitChangelog implements RendererInterface
             $logContent .= "\n";
             // Add tag header and date.
             $tagData = [$tag, $data['date']];
-            if ($tag == 'HEAD') {
-                $tagData = [$this->options['headSubject'], $this->options['nextTagDate']];
+            if ($tag === '') {
+                $tagData = [$this->options['headTagName'], $this->options['headTagDate']];
             }
 
             $logContent .= str_replace(['{tag}', '{date}'], $tagData, $this->formatTag) . "\n\n";

--- a/src/Renderers/MarkDown.php
+++ b/src/Renderers/MarkDown.php
@@ -55,18 +55,18 @@ class MarkDown extends GitChangelog implements RendererInterface
      */
     public $formatTag = '## {tag} ({date})';
     /**
-     * @var string Format of subjects. {subject} is replaced by commit subjects, {hashes} is replaced by the formatted
+     * @var string Format of titles. {title} is replaced by commit titles, {hashes} is replaced by the formatted
      *             commit hashes.
      */
-    public $formatSubject = '* {subject} {hashes}';
+    public $formatTitle = '* {title} {hashes}';
     /**
-     * @var string Url to commit view of the remote repository. If set, hashes of commit subjects are converted into
+     * @var string Url to commit view of the remote repository. If set, hashes of commit titles are converted into
      *             links which refer to the corresponding commit at the remote.
      *             {hash} is replaced by the commits hash id.
      */
     public $commitUrl;
     /**
-     * @var string Url to Issue tracker of the repository. If set, issue references in commit subject are converted into
+     * @var string Url to Issue tracker of the repository. If set, issue references in commit title are converted into
      *             links which refers to the corresponding issue at the tracker.
      *             {issue} is replaced by the issue number.
      */
@@ -87,6 +87,7 @@ class MarkDown extends GitChangelog implements RendererInterface
 
         if (!$commitData) {
             $this->changelog = "$logContent\n{$this->options['noChangesMessage']}\n";
+
             return;
         }
 
@@ -104,31 +105,31 @@ class MarkDown extends GitChangelog implements RendererInterface
 
             $logContent .= str_replace(['{tag}', '{date}'], $tagData, $this->formatTag) . "\n\n";
 
-            // No subjects present for this tag.
-            if (!$data['subjects']) {
-                $subject    = $this->options['noChangesMessage'];
-                $logContent .= rtrim(str_replace(['{subject}', '{hashes}'], [$subject, ''], $this->formatSubject));
+            // No titles present for this tag.
+            if (!$data['titles']) {
+                $title      = $this->options['noChangesMessage'];
+                $logContent .= rtrim(str_replace(['{title}', '{hashes}'], [$title, ''], $this->formatTitle));
                 $logContent .= "\n";
                 continue;
             }
 
-            // Sort commit subjects.
-            Utilities::natSort($data['subjects'], $this->options['subjectOrder']);
+            // Sort commit titles.
+            Utilities::natSort($data['titles'], $this->options['titleOrder']);
 
-            // Add commit subjects.
-            foreach ($data['subjects'] as $subjectKey => &$subject) {
+            // Add commit titles.
+            foreach ($data['titles'] as $titleKey => &$title) {
                 if ($this->issueUrl !== null) {
-                    $subject = preg_replace(
+                    $title = preg_replace(
                         '/#([0-9]+)/',
                         '[#$1](' . str_replace('{issue}', '$1', $this->issueUrl) . ')',
-                        $subject
+                        $title
                     );
                 }
                 $logContent .= rtrim(
                     str_replace(
-                        ['{subject}', '{hashes}'],
-                        [$subject, $this->formatHashes($data['hashes'][$subjectKey])],
-                        $this->formatSubject
+                        ['{title}', '{hashes}'],
+                        [$title, $this->formatHashes($data['hashes'][$titleKey])],
+                        $this->formatTitle
                     )
                 );
                 $logContent .= "\n";
@@ -139,7 +140,7 @@ class MarkDown extends GitChangelog implements RendererInterface
     }
 
     /**
-     * Format the hashes of a commit subject into a string.
+     * Format the hashes of a commit title into a string.
      *
      * Each hash is formatted into a link as defined by property commitUrl.
      * After formatting, all hashes are concatenated to a single line, comma separated.

--- a/src/Renderers/MarkDown.php
+++ b/src/Renderers/MarkDown.php
@@ -113,7 +113,7 @@ class MarkDown extends GitChangelog implements RendererInterface
             }
 
             // Sort commit subjects.
-            Utilities::natSort($data['subjects'], $this->options['commitOrder']);
+            Utilities::natSort($data['subjects'], $this->options['subjectOrder']);
 
             // Add commit subjects.
             foreach ($data['subjects'] as $subjectKey => &$subject) {

--- a/src/Renderers/MarkDown.php
+++ b/src/Renderers/MarkDown.php
@@ -70,7 +70,7 @@ class MarkDown extends GitChangelog implements RendererInterface
      *             links which refers to the corresponding issue at the tracker.
      *             {issue} is replaced by the issue number.
      */
-    public $issueUrl = 'https://github.com/DigiLive/gitChangelog/issues/{issue}';
+    public $issueUrl;
 
     /**
      * Generate the changelog.
@@ -86,7 +86,8 @@ class MarkDown extends GitChangelog implements RendererInterface
         $commitData = $this->fetchCommitData();
 
         if (!$commitData) {
-            $this->changelog = "\n$logContent{$this->options['noChangesMessage']}\n";
+            $this->changelog = "$logContent\n{$this->options['noChangesMessage']}\n";
+            return;
         }
 
         if (!$this->options['tagOrderDesc']) {
@@ -106,7 +107,7 @@ class MarkDown extends GitChangelog implements RendererInterface
             // No subjects present for this tag.
             if (!$data['subjects']) {
                 $subject    = $this->options['noChangesMessage'];
-                $logContent .= str_replace(['{subject}', '{hashes}'], [$subject, ''], $this->formatSubject);
+                $logContent .= rtrim(str_replace(['{subject}', '{hashes}'], [$subject, ''], $this->formatSubject));
                 $logContent .= "\n";
                 continue;
             }
@@ -156,10 +157,13 @@ class MarkDown extends GitChangelog implements RendererInterface
             return '';
         }
 
-        foreach ($hashes as &$hash) {
-            $hash = "[$hash](" . str_replace('{hash}', $hash, $this->commitUrl) . ')';
+        if ($this->commitUrl !== null) {
+            foreach ($hashes as &$hash) {
+                $hash = "[$hash](" . str_replace('{hash}', $hash, $this->commitUrl) . ')';
+            }
+            unset($hash);
         }
-        unset($hash);
+
         $hashes = implode(', ', $hashes);
 
         return "($hashes)";

--- a/src/Renderers/MarkDown.php
+++ b/src/Renderers/MarkDown.php
@@ -62,7 +62,7 @@ class MarkDown extends GitChangelog implements RendererInterface
     /**
      * @var string Url to commit view of the remote repository. If set, hashes of commit subjects are converted into
      *             links which refer to the corresponding commit at the remote.
-     *             {hash} is replaced by the issue number.
+     *             {hash} is replaced by the commits hash id.
      */
     public $commitUrl;
     /**

--- a/tests/GitChangeLogTest.php
+++ b/tests/GitChangeLogTest.php
@@ -72,16 +72,15 @@ class GitChangelogTest extends TestCase
         $changelog = new GitChangelog();
 
         $tags = $changelog->fetchTags();
-        $this->assertEquals('HEAD', reset($tags));
+        $this->assertSame('', reset($tags));
     }
 
     public function testFetchTagsUncached()
     {
         $changelog = new GitChangelog();
-        $changelog->setFromTag('HEAD');
+        $changelog->setFromTag('');
 
-        $tags = $changelog->fetchTags(true);
-        $this->assertEquals('HEAD', reset($tags));
+        $this->assertEquals([''], $changelog->fetchTags(true));
     }
 
     public function testFetchTagsThrowsExceptionOnInvalidFromTag()
@@ -206,7 +205,7 @@ class GitChangelogTest extends TestCase
             $commitData   = $changeLog->fetchCommitData();
             $firstElement = reset($commitData);
 
-            $this->assertEquals('HEAD', key($commitData));
+            $this->assertSame('', key($commitData));
             $this->assertArrayHasKey('date', $firstElement);
             $this->assertArrayHasKey('subjects', $firstElement);
             $this->assertArrayHasKey('hashes', $firstElement);
@@ -220,8 +219,8 @@ class GitChangelogTest extends TestCase
         $changeLog = new GitChangelog();
 
         // Test setting tag value.
-        $changeLog->setFromTag('HEAD');
-        $this->assertEquals('HEAD', $this->getPrivateProperty($changeLog, 'fromTag'));
+        $changeLog->setFromTag('');
+        $this->assertEquals('', $this->getPrivateProperty($changeLog, 'fromTag'));
 
         // Test removing tag value.
         $changeLog->setFromTag();
@@ -234,6 +233,8 @@ class GitChangelogTest extends TestCase
 
     public function testBuildAscendingCommitOrder()
     {
+        // TODO: Move to renderer tests.
+        $this->markTestSkipped('GitChangelog does not build anymore. Create tests for added renderers.');
         $changeLog = new GitChangelog();
         $changeLog->setOptions('tagOrderDesc', false);
         $testValues     =
@@ -268,6 +269,8 @@ class GitChangelogTest extends TestCase
 
     public function testBuildDescendingCommitOrder()
     {
+        // TODO: Move to renderer tests.
+        $this->markTestSkipped('GitChangelog does not build anymore. Create tests for added renderers.');
         $changeLog = new GitChangelog();
         $changeLog->setOptions('commitOrder', 'DESC');
         $testValues     =
@@ -350,12 +353,12 @@ class GitChangelogTest extends TestCase
         $changeLog = new GitChangelog();
 
         // Test setting tag value.
-        $changeLog->setToTag('HEAD');
-        $this->assertEquals('HEAD', $this->getPrivateProperty($changeLog, 'toTag'));
+        $changeLog->setToTag('');
+        $this->assertEquals('', $this->getPrivateProperty($changeLog, 'toTag'));
 
         // Test removing tag value.
         $changeLog->setToTag();
-        $this->assertEquals('HEAD', $this->getPrivateProperty($changeLog, 'toTag'));
+        $this->assertSame('', $this->getPrivateProperty($changeLog, 'toTag'));
 
         // Test exception.
         $this->expectException('Exception');
@@ -365,7 +368,7 @@ class GitChangelogTest extends TestCase
     public function testRemoveLabel()
     {
         $changeLog = new GitChangelog();
-
+        // FIXME: Set test labels because default labels might be empty.
         $defaultLabels = $this->getPrivateProperty($changeLog, 'labels');
 
         // Test with array parameter.
@@ -377,6 +380,7 @@ class GitChangelogTest extends TestCase
         $changeLog->removeLabel('newLabel1', 'newLabel2');
         array_shift($defaultLabels);
         $this->assertEquals(['newLabel3'], $this->getPrivateProperty($changeLog, 'labels'));
+        // TODO: Add test for removing non existing label.
     }
 
     public function testSave()
@@ -437,23 +441,32 @@ class GitChangelogTest extends TestCase
         // Set multiple options at once.
         $changeLog->setOptions(
             [
-                'logHeader'   => 'Test1',
-                'headSubject' => 'Test2',
+                'logHeader' => 'Test1',
+                'headTagName'   => 'Test2',
             ]
         );
         $this->assertEquals('Test1', $this->getPrivateProperty($changeLog, 'options')['logHeader']);
-        $this->assertEquals('Test2', $this->getPrivateProperty($changeLog, 'options')['headSubject']);
+        $this->assertEquals('Test2', $this->getPrivateProperty($changeLog, 'options')['headTagName']);
 
         // Set single option.
         $changeLog->setOptions('logHeader', 'Test');
         $this->assertEquals('Test', $this->getPrivateProperty($changeLog, 'options')['logHeader']);
     }
 
-    public function testSetOptionsThrowsException()
+    public function testSetOptionsThrowsExceptionOnInvalidOption()
     {
         $changeLog = new GitChangelog();
 
         $this->expectException('InvalidArgumentException');
         $changeLog->setOptions('NotExistingOption', 'Test');
+    }
+
+    public function testSetOptionsThrowsExceptionOnInvalidHeadTagNameValue()
+    {
+        $changeLog = new GitChangelog();
+        $this->setPrivateProperty($changeLog, 'gitTags', ['Test']);
+
+        $this->expectException('InvalidArgumentException');
+        $changeLog->setOptions('headTagName', 'Test');
     }
 }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1,0 +1,157 @@
+<?php
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2020, Ferry Cools (DigiLive)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace DigiLive\GitChangelog\Tests;
+
+use DigiLive\GitChangelog\Renderers\Html;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * Class HtmlTest
+ *
+ * PHPUnit tests for class Html
+ *
+ * @package DigiLive\GitChangelog\Tests
+ */
+class HtmlTest extends TestCase
+{
+    public function testBuildAscendingOrders()
+    {
+        $changeLog = new Html();
+        $changeLog->setOptions('tagOrderDesc', false);
+        $testValues     =
+            [
+                // No tags.
+                [],
+                // Head Revision included.
+                ['' => ['date' => 'B', 'subjects' => ['#1', 'D'], 'hashes' => [['E'], ['F']]]],
+                // Dummy tag, no commits.
+                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                // Dummy tag and commits.
+                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+                // Dummy tag and commits to be formatted.
+                ['A' => ['date' => 'B', 'subjects' => ['#1'], 'hashes' => [['0123456']]]],
+            ];
+        $expectedValues =
+            [
+                //No tags
+                '<h1>Changelog</h1><p>No changes.</p>',
+                // Head Revision included.
+                '<h1>Changelog</h1><h2>Upcoming changes (Undetermined)</h2><ul><li>#1 (E)</li><li>D (F)</li></ul>',
+                // Dummy tag, no commits.
+                '<h1>Changelog</h1><h2>A (B)</h2><ul><li>No changes.</li></ul>',
+                // Dummy tag and commits.
+                '<h1>Changelog</h1><h2>A (B)</h2><ul><li>C (E, F)</li><li>D (G)</li></ul>',
+                // Dummy tag and commits to be formatted, but they're not.
+                '<h1>Changelog</h1><h2>A (B)</h2><ul><li>#1 (0123456)</li></ul>',
+                // Dummy tag and commits to be formatted, and they are.
+                '<h1>Changelog</h1><h2>A (B)</h2><ul><li><a href="<Issue>1</Issue>">#1</a> (<a href="<Commit>0123456</Commit>">0123456</a>)</li></ul>',
+                // Dummy tag and commits to be formatted, but hashes are disabled.
+                '<h1>Changelog</h1><h2>A (B)</h2><ul><li><a href="<Issue>1</Issue>">#1</a> </li></ul>',
+            ];
+
+        next($testValues);
+        foreach ($testValues as $key => $value) {
+            $this->setPrivateProperty($changeLog, 'commitData', $value);
+            $changeLog->build();
+            $this->assertEquals($expectedValues[$key], $changeLog->get());
+        }
+
+        // Test formatting of issues and hashes.
+        $changeLog->issueUrl  = '<Issue>{issue}</Issue>';
+        $changeLog->commitUrl = '<Commit>{hash}</Commit>';
+        $changeLog->build();
+        $this->assertEquals($expectedValues[5], $changeLog->get());
+        // Disable hashes
+        $changeLog->setOptions('addHashes', false);
+        $changeLog->build();
+        $this->assertEquals($expectedValues[6], $changeLog->get());
+    }
+
+    /**
+     * Sets a private or protected property on a given object via reflection
+     *
+     * @param   object  $object    - Instance in which the private or protected value is being modified.
+     * @param   string  $property  - Property of instance which is being modified.
+     * @param           $value     - New value of the property which is being modified.
+     *
+     * @return void
+     * @throws ReflectionException If no property exists by that name.
+     */
+    private function setPrivateProperty(object $object, string $property, $value): void
+    {
+        $reflection         = new ReflectionClass($object);
+        $reflectionProperty = $reflection->getProperty($property);
+
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($object, $value);
+    }
+
+    public function testBuildDescendingOrders()
+    {
+        $changeLog = new Html();
+        $changeLog->setOptions('commitOrder', 'DESC');
+        $testValues     =
+            [
+                // No tags.
+                [],
+                // Head Revision included.
+                ['' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
+                // Dummy tag, no commits.
+                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                // Dummy tag and commits.
+                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+            ];
+        $expectedValues =
+            [
+                //No tags
+                '<h1>Changelog</h1><p>No changes.</p>',
+                // Head Revision included.
+                '<h1>Changelog</h1><h2>Upcoming changes (Undetermined)</h2><ul><li>D (F)</li><li>C (E)</li></ul>',
+                // Dummy tag, no commits.
+                '<h1>Changelog</h1><h2>A (B)</h2><ul><li>No changes.</li></ul>',
+                // Dummy tag and commits.
+                '<h1>Changelog</h1><h2>A (B)</h2><ul><li>D (G)</li><li>C (E, F)</li></ul>',
+            ];
+
+        // Test formatting of issues and hashes.
+        foreach ($testValues as $key => $value) {
+            $this->setPrivateProperty($changeLog, 'commitData', $value);
+            $changeLog->build();
+            $this->assertEquals($expectedValues[$key], $changeLog->get());
+        }
+    }
+}

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -123,7 +123,7 @@ class HtmlTest extends TestCase
     public function testBuildDescendingOrders()
     {
         $changeLog = new Html();
-        $changeLog->setOptions('commitOrder', 'DESC');
+        $changeLog->setOptions('subjectOrder', 'DESC');
         $testValues     =
             [
                 // No tags.

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -57,13 +57,13 @@ class HtmlTest extends TestCase
                 // No tags.
                 [],
                 // Head Revision included.
-                ['' => ['date' => 'B', 'subjects' => ['#1', 'D'], 'hashes' => [['E'], ['F']]]],
+                ['' => ['date' => 'B', 'titles' => ['#1', 'D'], 'hashes' => [['E'], ['F']]]],
                 // Dummy tag, no commits.
-                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                ['A' => ['date' => 'B', 'titles' => [], 'hashes' => []]],
                 // Dummy tag and commits.
-                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+                ['A' => ['date' => 'B', 'titles' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
                 // Dummy tag and commits to be formatted.
-                ['A' => ['date' => 'B', 'subjects' => ['#1'], 'hashes' => [['0123456']]]],
+                ['A' => ['date' => 'B', 'titles' => ['#1'], 'hashes' => [['0123456']]]],
             ];
         $expectedValues =
             [
@@ -123,17 +123,17 @@ class HtmlTest extends TestCase
     public function testBuildDescendingOrders()
     {
         $changeLog = new Html();
-        $changeLog->setOptions('subjectOrder', 'DESC');
+        $changeLog->setOptions('titleOrder', 'DESC');
         $testValues     =
             [
                 // No tags.
                 [],
                 // Head Revision included.
-                ['' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
+                ['' => ['date' => 'B', 'titles' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
                 // Dummy tag, no commits.
-                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                ['A' => ['date' => 'B', 'titles' => [], 'hashes' => []]],
                 // Dummy tag and commits.
-                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+                ['A' => ['date' => 'B', 'titles' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
             ];
         $expectedValues =
             [

--- a/tests/MarkDownTest.php
+++ b/tests/MarkDownTest.php
@@ -122,7 +122,7 @@ class MarkDownTest extends TestCase
     public function testBuildDescendingOrders()
     {
         $changeLog = new MarkDown();
-        $changeLog->setOptions('commitOrder', 'DESC');
+        $changeLog->setOptions('subjectOrder', 'DESC');
         $testValues     =
             [
                 // No tags.

--- a/tests/MarkDownTest.php
+++ b/tests/MarkDownTest.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2020, Ferry Cools (DigiLive)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace DigiLive\GitChangelog\Tests;
+
+use DigiLive\GitChangelog\Renderers\MarkDown;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * Class MarkDownTest
+ *
+ * PHPUnit tests of class MarkDown
+ *
+ * @package DigiLive\GitChangelog\Tests
+ */
+class MarkDownTest extends TestCase
+{
+    public function testBuildAscendingOrders()
+    {
+        $changeLog = new MarkDown();
+        $changeLog->setOptions('tagOrderDesc', false);
+        $testValues     =
+            [
+                // No tags.
+                [],
+                // Head Revision included.
+                ['' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
+                // Dummy tag, no commits.
+                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                // Dummy tag and commits.
+                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+                // Dummy tag and commits to be formatted.
+                ['A' => ['date' => 'B', 'subjects' => ['#1'], 'hashes' => [['0123456']]]],
+            ];
+        $expectedValues =
+            [
+                //No tags
+                "# Changelog\n\nNo changes.\n",
+                // Head Revision included.
+                "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* C (E)\n* D (F)\n",
+                // Dummy tag, no commits.
+                "# Changelog\n\n## A (B)\n\n* No changes.\n",
+                // Dummy tag and commits.
+                "# Changelog\n\n## A (B)\n\n* C (E, F)\n* D (G)\n",
+                // Dummy tag and commits to be formatted, but they're not.
+                "# Changelog\n\n## A (B)\n\n* #1 (0123456)\n",
+                // Dummy tag and commits to be formatted, and they are.
+                "# Changelog\n\n## A (B)\n\n* [#1](<Issue>1</Issue>) ([0123456](<Commit>0123456</Commit>))\n",
+                // Dummy tag and commits to be formatted, but hashes are disabled.
+                "# Changelog\n\n## A (B)\n\n* [#1](<Issue>1</Issue>)\n",
+            ];
+
+        foreach ($testValues as $key => $value) {
+            $this->setPrivateProperty($changeLog, 'commitData', $value);
+            $changeLog->build();
+            $this->assertEquals($expectedValues[$key], $changeLog->get());
+        }
+
+        // Test formatting of issues and hashes.
+        $changeLog->issueUrl  = '<Issue>{issue}</Issue>';
+        $changeLog->commitUrl = '<Commit>{hash}</Commit>';
+        $changeLog->build();
+        $this->assertEquals($expectedValues[5], $changeLog->get());
+        // Disable hashes
+        $changeLog->setOptions('addHashes', false);
+        $changeLog->build();
+        $this->assertEquals($expectedValues[6], $changeLog->get());
+    }
+
+    /**
+     * Sets a private or protected property on a given object via reflection
+     *
+     * @param   object  $object    - Instance in which the private or protected value is being modified.
+     * @param   string  $property  - Property of instance which is being modified.
+     * @param           $value     - New value of the property which is being modified.
+     *
+     * @return void
+     * @throws ReflectionException If no property exists by that name.
+     */
+    private function setPrivateProperty(object $object, string $property, $value): void
+    {
+        $reflection         = new ReflectionClass($object);
+        $reflectionProperty = $reflection->getProperty($property);
+
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($object, $value);
+    }
+
+    public function testBuildDescendingOrders()
+    {
+        $changeLog = new MarkDown();
+        $changeLog->setOptions('commitOrder', 'DESC');
+        $testValues     =
+            [
+                // No tags.
+                [],
+                // Head Revision included.
+                ['' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
+                // Dummy tag, no commits.
+                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                // Dummy tag and commits.
+                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+            ];
+        $expectedValues =
+            [
+                //No tags
+                "# Changelog\n\nNo changes.\n",
+                // Head Revision included.
+                "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* D (F)\n* C (E)\n",
+                // Dummy tag, no commits.
+                "# Changelog\n\n## A (B)\n\n* No changes.\n",
+                // Dummy tag and commits.
+                "# Changelog\n\n## A (B)\n\n* D (G)\n* C (E, F)\n",
+            ];
+
+        foreach ($testValues as $key => $value) {
+            $this->setPrivateProperty($changeLog, 'commitData', $value);
+            $changeLog->build();
+            $this->assertEquals($expectedValues[$key], $changeLog->get());
+        }
+    }
+}

--- a/tests/MarkDownTest.php
+++ b/tests/MarkDownTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * BSD 3-Clause License
  *
@@ -57,13 +58,13 @@ class MarkDownTest extends TestCase
                 // No tags.
                 [],
                 // Head Revision included.
-                ['' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
+                ['' => ['date' => 'B', 'titles' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
                 // Dummy tag, no commits.
-                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                ['A' => ['date' => 'B', 'titles' => [], 'hashes' => []]],
                 // Dummy tag and commits.
-                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+                ['A' => ['date' => 'B', 'titles' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
                 // Dummy tag and commits to be formatted.
-                ['A' => ['date' => 'B', 'subjects' => ['#1'], 'hashes' => [['0123456']]]],
+                ['A' => ['date' => 'B', 'titles' => ['#1'], 'hashes' => [['0123456']]]],
             ];
         $expectedValues =
             [
@@ -122,17 +123,17 @@ class MarkDownTest extends TestCase
     public function testBuildDescendingOrders()
     {
         $changeLog = new MarkDown();
-        $changeLog->setOptions('subjectOrder', 'DESC');
+        $changeLog->setOptions('titleOrder', 'DESC');
         $testValues     =
             [
                 // No tags.
                 [],
                 // Head Revision included.
-                ['' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
+                ['' => ['date' => 'B', 'titles' => ['C', 'D'], 'hashes' => [['E'], ['F']]]],
                 // Dummy tag, no commits.
-                ['A' => ['date' => 'B', 'subjects' => [], 'hashes' => []]],
+                ['A' => ['date' => 'B', 'titles' => [], 'hashes' => []]],
                 // Dummy tag and commits.
-                ['A' => ['date' => 'B', 'subjects' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
+                ['A' => ['date' => 'B', 'titles' => ['C', 'D'], 'hashes' => [['E', 'F'], ['G']]]],
             ];
         $expectedValues =
             [


### PR DESCRIPTION
- Renamed option `headSubject` to `headTagName` because the option
  involves a tag name instead of subject.

- Renamed option `nextTagDate` to `headTagDate`.

- Option ~~headSubject~~ headTagName can't be set to an existing tag
  name anymore. Having duplicate tag names is ambiguous.

- Reference to HEAD revision in Gitchangelog::gitTags changed from
  'HEAD' to ''. Any non empty value could result in duplicate tag names.