### PR TITLE
Enable PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.3"
+        "php": ">=7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/tests/GitChangelogTest.php
+++ b/tests/GitChangelogTest.php
@@ -186,6 +186,9 @@ class GitChangelogTest extends TestCase
         $changeLog = new GitChangelog();
 
         $this->expectNotice();
+        if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
+            $this->expectWarning();
+        }
         $changeLog->setLabels([]);
     }
 


### PR DESCRIPTION
In order to get php-diff working in dev with PHP 8, this lib needs to be upgraded.