### PR TITLE
Fix #14 - Ambiguous argument 'tag^'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add force fetching tags when fetching commit data ([521d2e4](https://github.com/DigiLive/gitChangelog/commit/521d2e4))
 * Add setting gitPath property to constructor ([60fa232](https://github.com/DigiLive/gitChangelog/commit/60fa232))
 * Add test for fetching duplicate tags ([5377c20](https://github.com/DigiLive/gitChangelog/commit/5377c20))
+* Fix [#14](https://github.com/DigiLive/gitChangelog/issues/14) - Ambiguous argument 'tag^' ([43e1f4d](https://github.com/DigiLive/gitChangelog/commit/43e1f4d))
 * Fix setting wrong gitPath ([871f440](https://github.com/DigiLive/gitChangelog/commit/871f440))
 * Optimize fetching commit data ([15543cb](https://github.com/DigiLive/gitChangelog/commit/15543cb))
 

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -272,7 +272,7 @@ class GitChangelog
         $includeMergeCommits = $this->options['includeMergeCommits'] ? '' : '--no-merges';
         foreach ($gitTags as $tag) {
             $rangeStart = next($gitTags);
-            $tagRange   = $rangeStart !== false ? "$rangeStart..$tag" : "$tag^";
+            $tagRange   = $rangeStart !== false ? "$rangeStart..$tag" : "$tag";
 
             $commitData[$tag]['date'] =
                 shell_exec("git $gitPath log -1 --pretty=format:%ad --date=short $tag") ?? 'Error';


### PR DESCRIPTION
Fix #14 - Ambiguous argument 'tag^'

Error is raised when repo first commit is tagged.
CMD: no differences between tag^ and tag.
PS/Bash: tag^ excludes tagged commit and tag includes tagged commit.

$tag^ means parent of tagged commit.
Note: On Windows in cmd.exe, ^ is a special character and needs to be
treated differently. You can either double it (^^) or put the commit
reference in quotes.