### PR TITLE
Add grouping of links to markdown renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 ## Next Release (Soon)
 
-* Add force fetching tags when fetching commit data ([521d2e4](https://github.com/DigiLive/gitChangelog/commit/521d2e4))
-* Add setting gitPath property to constructor ([60fa232](https://github.com/DigiLive/gitChangelog/commit/60fa232))
-* Add test for fetching duplicate tags ([5377c20](https://github.com/DigiLive/gitChangelog/commit/5377c20))
-* Fix [#14](https://github.com/DigiLive/gitChangelog/issues/14) - Ambiguous argument 'tag^' ([43e1f4d](https://github.com/DigiLive/gitChangelog/commit/43e1f4d))
-* Fix setting wrong gitPath ([871f440](https://github.com/DigiLive/gitChangelog/commit/871f440))
-* Optimize fetching commit data ([15543cb](https://github.com/DigiLive/gitChangelog/commit/15543cb))
+* Add force fetching tags when fetching commit data ([521d2e4][0])
+* Add grouping of links to markdown renderer ([8dd502e][1])
+* Add setting gitPath property to constructor ([60fa232][2])
+* Add test for fetching duplicate tags ([5377c20][3])
+* Fix [#14][4] - Ambiguous argument 'tag^' ([0127ce2][5])
+* Fix setting wrong gitPath ([871f440][6])
+* Optimize fetching commit data ([15543cb][7])
 
 ## v1.0.1 (2021-06-09)
 
-* Add compatibility with PHP version 8 ([cb04682](https://github.com/DigiLive/gitChangelog/commit/cb04682))
-* Fix duplicating tags on re-fetching tags ([d30c8cd](https://github.com/DigiLive/gitChangelog/commit/d30c8cd))
+* Add compatibility with PHP version 8 ([cb04682][8])
+* Fix duplicating tags on re-fetching tags ([d30c8cd][9])
 
 ## v1.0.0 (2020-12-16)
 
@@ -20,50 +21,110 @@
 
 ## v1.0.0-rc.1 (2020-11-30)
 
-* Add PhpUnit tests for class Html and MarkDown ([a4890bc](https://github.com/DigiLive/gitChangelog/commit/a4890bc))
-* Add code coverage tags ([7ce91b8](https://github.com/DigiLive/gitChangelog/commit/7ce91b8))
-* Add formatting of issues ids & hashes to hyperlink ([10816fb](https://github.com/DigiLive/gitChangelog/commit/10816fb))
-* Add issue templates ([5bbf5ef](https://github.com/DigiLive/gitChangelog/commit/5bbf5ef), [6d34e1c](https://github.com/DigiLive/gitChangelog/commit/6d34e1c))
-* Add setting base content by value or file content. ([93ca694](https://github.com/DigiLive/gitChangelog/commit/93ca694))
-* Fix [#7](https://github.com/DigiLive/gitChangelog/issues/7), Fix [#8](https://github.com/DigiLive/gitChangelog/issues/8) ([d4e352e](https://github.com/DigiLive/gitChangelog/commit/d4e352e))
-* Fix PhpUnit tests for GitChangelog ([b62ded6](https://github.com/DigiLive/gitChangelog/commit/b62ded6))
-* Fix docBlock of GitChangelog::$labels ([1fea85e](https://github.com/DigiLive/gitChangelog/commit/1fea85e))
-* Fix filename to PSR4 rules ([27911a9](https://github.com/DigiLive/gitChangelog/commit/27911a9))
-* Fix html renderer ([c66b572](https://github.com/DigiLive/gitChangelog/commit/c66b572))
-* Fix markdown renderer ([ab29669](https://github.com/DigiLive/gitChangelog/commit/ab29669))
-* Optimize Git execution and Fix docBlocks ([fc79a58](https://github.com/DigiLive/gitChangelog/commit/fc79a58))
+* Add PhpUnit tests for class Html and MarkDown ([a4890bc][10])
+* Add code coverage tags ([7ce91b8][11])
+* Add formatting of issues ids & hashes to hyperlink ([10816fb][12])
+* Add issue templates ([5bbf5ef][13], [6d34e1c][14])
+* Add setting base content by value or file content. ([93ca694][15])
+* Fix [#7][16], Fix [#8][17] ([d4e352e][18])
+* Fix PhpUnit tests for GitChangelog ([b62ded6][19])
+* Fix docBlock of GitChangelog::$labels ([1fea85e][20])
+* Fix filename to PSR4 rules ([27911a9][21])
+* Fix html renderer ([c66b572][22])
+* Fix markdown renderer ([ab29669][23])
+* Optimize Git execution and Fix docBlocks ([fc79a58][24])
 
 ## v0.4.0 (2020-10-28)
 
-* Add separate renderers for GitChangelog ([2df97ee](https://github.com/DigiLive/gitChangelog/commit/2df97ee))
+* Add separate renderers for GitChangelog ([2df97ee][25])
 
 ## v0.3.0 (2020-10-26)
 
-* Fix get method ([a9a9804](https://github.com/DigiLive/gitChangelog/commit/a9a9804))
-* Optimize save method ([d0b1a07](https://github.com/DigiLive/gitChangelog/commit/d0b1a07))
+* Fix get method ([a9a9804][26])
+* Optimize save method ([d0b1a07][27])
 
 ## v0.2.0 (2020-10-23)
 
-* Add Option to sort the changelog by tags in ascending/descending order ([5f6473d](https://github.com/DigiLive/gitChangelog/commit/5f6473d))
-* Add PHPUnit tests for GitChangelog::setOptions() ([94b1301](https://github.com/DigiLive/gitChangelog/commit/94b1301))
-* Add formatting of a single hash ([392db51](https://github.com/DigiLive/gitChangelog/commit/392db51))
-* Add git ignoring ([a574e81](https://github.com/DigiLive/gitChangelog/commit/a574e81))
-* Add options property which replaces individual option properties ([2357497](https://github.com/DigiLive/gitChangelog/commit/2357497))
-* Add option to set another git repository ([f8e2449](https://github.com/DigiLive/gitChangelog/commit/f8e2449))
-* Add setting sorting key for fetching tags ([a477f4f](https://github.com/DigiLive/gitChangelog/commit/a477f4f))
-* Add sorting order of commit subjects ([37389dc](https://github.com/DigiLive/gitChangelog/commit/37389dc))
-* Bump php version ([101b8fa](https://github.com/DigiLive/gitChangelog/commit/101b8fa))
-* Fix PHPUnit tests ([52de68a](https://github.com/DigiLive/gitChangelog/commit/52de68a), [d888afd](https://github.com/DigiLive/gitChangelog/commit/d888afd))
-* Optimize commitData processing ([6dc2bee](https://github.com/DigiLive/gitChangelog/commit/6dc2bee))
-* Optimize method GitChangeLog::build() ([31d33af](https://github.com/DigiLive/gitChangelog/commit/31d33af))
+* Add Option to sort the changelog by tags in ascending/descending order
+([5f6473d][28])
+
+* Add PHPUnit tests for GitChangelog::setOptions() ([94b1301][29])
+
+* Add formatting of a single hash ([392db51][30])
+
+* Add git ignoring ([a574e81][31])
+
+* Add options property which replaces individual option properties
+([2357497][32])
+
+* Add option to set another git repository ([f8e2449][33])
+
+* Add setting sorting key for fetching tags ([a477f4f][34])
+
+* Add sorting order of commit subjects ([37389dc][35])
+
+* Bump php version ([101b8fa][36])
+
+* Fix PHPUnit tests ([52de68a][37], [d888afd][38])
+
+* Optimize commitData processing ([6dc2bee][39])
+
+* Optimize method GitChangeLog::build() ([31d33af][40])
 
 ## v0.1.1 (2020-10-21)
 
-* Add changelog ([da391ec](https://github.com/DigiLive/gitChangelog/commit/da391ec))
-* Bump php version ([ece339e](https://github.com/DigiLive/gitChangelog/commit/ece339e))
-* Cut composer.lock ([580233b](https://github.com/DigiLive/gitChangelog/commit/580233b))
+* Add changelog ([da391ec][41])
+* Bump php version ([ece339e][42])
+* Cut composer.lock ([580233b][43])
 
 ## v0.1.0 (2020-10-21)
 
-* Add changelog ([a4336bc](https://github.com/DigiLive/gitChangelog/commit/a4336bc))
-* Add library code ([731f58a](https://github.com/DigiLive/gitChangelog/commit/731f58a))
+* Add changelog ([a4336bc][44])
+* Add library code ([731f58a][45])
+
+[0]:https://github.com/DigiLive/gitChangelog/commit/521d2e4
+[1]:https://github.com/DigiLive/gitChangelog/commit/8dd502e
+[2]:https://github.com/DigiLive/gitChangelog/commit/60fa232
+[3]:https://github.com/DigiLive/gitChangelog/commit/5377c20
+[4]:https://github.com/DigiLive/gitChangelog/issues/14
+[5]:https://github.com/DigiLive/gitChangelog/commit/0127ce2
+[6]:https://github.com/DigiLive/gitChangelog/commit/871f440
+[7]:https://github.com/DigiLive/gitChangelog/commit/15543cb
+[8]:https://github.com/DigiLive/gitChangelog/commit/cb04682
+[9]:https://github.com/DigiLive/gitChangelog/commit/d30c8cd
+[10]:https://github.com/DigiLive/gitChangelog/commit/a4890bc
+[11]:https://github.com/DigiLive/gitChangelog/commit/7ce91b8
+[12]:https://github.com/DigiLive/gitChangelog/commit/10816fb
+[13]:https://github.com/DigiLive/gitChangelog/commit/5bbf5ef
+[14]:https://github.com/DigiLive/gitChangelog/commit/6d34e1c
+[15]:https://github.com/DigiLive/gitChangelog/commit/93ca694
+[16]:https://github.com/DigiLive/gitChangelog/issues/7
+[17]:https://github.com/DigiLive/gitChangelog/issues/8
+[18]:https://github.com/DigiLive/gitChangelog/commit/d4e352e
+[19]:https://github.com/DigiLive/gitChangelog/commit/b62ded6
+[20]:https://github.com/DigiLive/gitChangelog/commit/1fea85e
+[21]:https://github.com/DigiLive/gitChangelog/commit/27911a9
+[22]:https://github.com/DigiLive/gitChangelog/commit/c66b572
+[23]:https://github.com/DigiLive/gitChangelog/commit/ab29669
+[24]:https://github.com/DigiLive/gitChangelog/commit/fc79a58
+[25]:https://github.com/DigiLive/gitChangelog/commit/2df97ee
+[26]:https://github.com/DigiLive/gitChangelog/commit/a9a9804
+[27]:https://github.com/DigiLive/gitChangelog/commit/d0b1a07
+[28]:https://github.com/DigiLive/gitChangelog/commit/5f6473d
+[29]:https://github.com/DigiLive/gitChangelog/commit/94b1301
+[30]:https://github.com/DigiLive/gitChangelog/commit/392db51
+[31]:https://github.com/DigiLive/gitChangelog/commit/a574e81
+[32]:https://github.com/DigiLive/gitChangelog/commit/2357497
+[33]:https://github.com/DigiLive/gitChangelog/commit/f8e2449
+[34]:https://github.com/DigiLive/gitChangelog/commit/a477f4f
+[35]:https://github.com/DigiLive/gitChangelog/commit/37389dc
+[36]:https://github.com/DigiLive/gitChangelog/commit/101b8fa
+[37]:https://github.com/DigiLive/gitChangelog/commit/52de68a
+[38]:https://github.com/DigiLive/gitChangelog/commit/d888afd
+[39]:https://github.com/DigiLive/gitChangelog/commit/6dc2bee
+[40]:https://github.com/DigiLive/gitChangelog/commit/31d33af
+[41]:https://github.com/DigiLive/gitChangelog/commit/da391ec
+[42]:https://github.com/DigiLive/gitChangelog/commit/ece339e
+[43]:https://github.com/DigiLive/gitChangelog/commit/580233b
+[44]:https://github.com/DigiLive/gitChangelog/commit/a4336bc
+[45]:https://github.com/DigiLive/gitChangelog/commit/731f58a

--- a/src/Renderers/MarkDown.php
+++ b/src/Renderers/MarkDown.php
@@ -71,6 +71,15 @@ class MarkDown extends GitChangelog implements RendererInterface
      *             {issue} is replaced by the issue number.
      */
     public $issueUrl;
+    /**
+     * @var int Maximum length of the commit titles. Longer titles are word-wrapped, so they won't exceed this maximum.
+     */
+    public $titleLength = 80;
+
+    /**
+     * @var array Contains the urls of the reference links in the document.
+     */
+    private $links = [];
 
     /**
      * Generate the changelog.
@@ -82,7 +91,6 @@ class MarkDown extends GitChangelog implements RendererInterface
     public function build(): void
     {
         $logContent = "# {$this->options['logHeader']}\n";
-
         $commitData = $this->fetchCommitData();
 
         if (!$commitData) {
@@ -97,7 +105,7 @@ class MarkDown extends GitChangelog implements RendererInterface
 
         foreach ($commitData as $tag => $data) {
             $logContent .= "\n";
-            // Add tag header and date.
+            // Add tag header and date to log.
             $tagData = [$tag, $data['date']];
             if ($tag === '') {
                 $tagData = [$this->options['headTagName'], $this->options['headTagDate']];
@@ -107,8 +115,9 @@ class MarkDown extends GitChangelog implements RendererInterface
 
             // No titles present for this tag.
             if (!$data['titles']) {
-                $title      = $this->options['noChangesMessage'];
-                $logContent .= rtrim(str_replace(['{title}', '{hashes}'], [$title, ''], $this->formatTitle));
+                $logContent .= rtrim(
+                    str_replace(['{title}', '{hashes}'], [$this->options['noChangesMessage'], ''], $this->formatTitle)
+                );
                 $logContent .= "\n";
                 continue;
             }
@@ -116,24 +125,37 @@ class MarkDown extends GitChangelog implements RendererInterface
             // Sort commit titles.
             Utilities::natSort($data['titles'], $this->options['titleOrder']);
 
-            // Add commit titles.
+            // Add commit titles to log.
+            $tagContent = '';
             foreach ($data['titles'] as $titleKey => &$title) {
                 if ($this->issueUrl !== null) {
-                    $title = preg_replace(
-                        '/#([0-9]+)/',
-                        '[#$1](' . str_replace('{issue}', '$1', $this->issueUrl) . ')',
-                        $title
+                    $title = preg_replace_callback(
+                        '/#(\d+)/',
+                        function ($matches) {
+                            $this->links[] = str_replace('{issue}', $matches[1], $this->issueUrl);
+
+                            return "[$matches[0]][" . (count($this->links) - 1) . ']';
+                        },
+                        $title,
                     );
                 }
-                $logContent .= rtrim(
+
+                $tagContent .= rtrim(
                     str_replace(
                         ['{title}', '{hashes}'],
                         [$title, $this->formatHashes($data['hashes'][$titleKey])],
                         $this->formatTitle
                     )
-                );
-                $logContent .= "\n";
+                ) . "\n";
             }
+
+            $logContent .= $this->wordWrap($tagContent);
+        }
+
+        // Render links.
+        $logContent .= "\n";
+        foreach ($this->links as $index => $link) {
+            $logContent .= "[$index]:$link\n";
         }
 
         $this->changelog = $logContent;
@@ -144,7 +166,7 @@ class MarkDown extends GitChangelog implements RendererInterface
      *
      * Each hash is formatted into a link as defined by property commitUrl.
      * After formatting, all hashes are concatenated to a single line, comma separated.
-     * Finally this line is formatted as defined by property formatHashes.
+     * Finally, this line is formatted as defined by property formatHashes.
      *
      * @param   array  $hashes  Hashes to format
      *
@@ -160,7 +182,8 @@ class MarkDown extends GitChangelog implements RendererInterface
 
         if ($this->commitUrl !== null) {
             foreach ($hashes as &$hash) {
-                $hash = "[$hash](" . str_replace('{hash}', $hash, $this->commitUrl) . ')';
+                $this->links[] = str_replace('{hash}', $hash, $this->commitUrl);
+                $hash          = "[$hash][" . (count($this->links) - 1) . ']';
             }
             unset($hash);
         }
@@ -168,5 +191,22 @@ class MarkDown extends GitChangelog implements RendererInterface
         $hashes = implode(', ', $hashes);
 
         return "($hashes)";
+    }
+
+    /**
+     * Word-wrap a string to a maximum of chars.
+     *
+     * @param   string  $content  The tring to wrap.
+     *
+     * @return string The wrapped string.
+     */
+    private function wordWrap(string $content): string
+    {
+        $wrappedContent = wordwrap($content, $this->titleLength);
+        if ($wrappedContent != $content) {
+            $wrappedContent = ltrim(preg_replace('/^(\d+\.|[-*+] )/m', "\n$1", $wrappedContent));
+        }
+
+        return $wrappedContent;
     }
 }

--- a/src/Renderers/MarkDown.php
+++ b/src/Renderers/MarkDown.php
@@ -92,6 +92,7 @@ class MarkDown extends GitChangelog implements RendererInterface
     {
         $logContent = "# {$this->options['logHeader']}\n";
         $commitData = $this->fetchCommitData();
+        $this->links = [];
 
         if (!$commitData) {
             $this->changelog = "$logContent\n{$this->options['noChangesMessage']}\n";

--- a/tests/MarkDownTest.php
+++ b/tests/MarkDownTest.php
@@ -71,17 +71,17 @@ class MarkDownTest extends TestCase
                 //No tags
                 "# Changelog\n\nNo changes.\n",
                 // Head Revision included.
-                "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* C (E)\n* D (F)\n",
+                "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* C (E)\n* D (F)\n\n",
                 // Dummy tag, no commits.
-                "# Changelog\n\n## A (B)\n\n* No changes.\n",
+                "# Changelog\n\n## A (B)\n\n* No changes.\n\n",
                 // Dummy tag and commits.
-                "# Changelog\n\n## A (B)\n\n* C (E, F)\n* D (G)\n",
+                "# Changelog\n\n## A (B)\n\n* C (E, F)\n* D (G)\n\n",
                 // Dummy tag and commits to be formatted, but they're not.
-                "# Changelog\n\n## A (B)\n\n* #1 (0123456)\n",
+                "# Changelog\n\n## A (B)\n\n* #1 (0123456)\n\n",
                 // Dummy tag and commits to be formatted, and they are.
-                "# Changelog\n\n## A (B)\n\n* [#1](<Issue>1</Issue>) ([0123456](<Commit>0123456</Commit>))\n",
+                "# Changelog\n\n## A (B)\n\n* [#1][0] ([0123456][1])\n\n[0]:<Issue>1</Issue>\n[1]:<Commit>0123456</Commit>\n",
                 // Dummy tag and commits to be formatted, but hashes are disabled.
-                "# Changelog\n\n## A (B)\n\n* [#1](<Issue>1</Issue>)\n",
+                "# Changelog\n\n## A (B)\n\n* [#1][0]\n\n[0]:<Issue>1</Issue>\n",
             ];
 
         foreach ($testValues as $key => $value) {
@@ -140,11 +140,11 @@ class MarkDownTest extends TestCase
                 //No tags
                 "# Changelog\n\nNo changes.\n",
                 // Head Revision included.
-                "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* D (F)\n* C (E)\n",
+                "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* D (F)\n* C (E)\n\n",
                 // Dummy tag, no commits.
-                "# Changelog\n\n## A (B)\n\n* No changes.\n",
+                "# Changelog\n\n## A (B)\n\n* No changes.\n\n",
                 // Dummy tag and commits.
-                "# Changelog\n\n## A (B)\n\n* D (G)\n* C (E, F)\n",
+                "# Changelog\n\n## A (B)\n\n* D (G)\n* C (E, F)\n\n",
             ];
 
         foreach ($testValues as $key => $value) {


### PR DESCRIPTION
To satisfy the markdown linter, links are now embedded as
reference-style links instead of standard links.
Also, the line widths of the commit titles are wrapped to 80 chars max.