### PR TITLE
Add symfony/process package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.3 || ^8.0",
+        "symfony/process": "^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -389,14 +389,12 @@ class GitChangelog
      *
      * Optionally the generated changelog is appended with the content of property GitChangelog::$baseContent.
      *
-     * @SuppressWarnings(PHPMD.ErrorControlOperator)
-     *
-     * @param   bool  $append  [Optional] Set to true to append the changelog with base content.
+     * @param   bool  $append  Set to true to append the changelog with base content.
      *
      * @return string The generated changelog, optionally followed by base content.
      * @see GitChangelog::$baseContent
      */
-    public function get(bool $append = false): string
+    public function get(bool $append): string
     {
         return $this->changelog . ($append ? $this->baseContent : '');
     }

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -425,11 +425,11 @@ class GitChangelog
      *
      * Note: This method does not affect the contents of the pre-fetched tags.
      *
-     * @param   mixed  $tag  The newest tag to include.
+     * @param   ?string  $tag  The newest tag to include.
      *
      * @see GitChangelog::fetchTags()
      */
-    public function setToTag($tag = null): void
+    public function setToTag(string $tag = null): void
     {
         $tag = $tag ?? '';
         Utilities::arraySearch($tag, $this->gitTags);
@@ -443,11 +443,11 @@ class GitChangelog
      *
      * Note: This method does not affect the contents of the pre-fetched tags.
      *
-     * @param   mixed  $tag  The oldest tag to include.
+     * @param   ?string  $tag  The oldest tag to include.
      *
      * @see GitChangelog::fetchTags()
      */
-    public function setFromTag($tag = null): void
+    public function setFromTag(string $tag = null): void
     {
         if (null !== $tag) {
             Utilities::arraySearch($tag, $this->gitTags);
@@ -473,7 +473,7 @@ class GitChangelog
             try {
                 $key = Utilities::arraySearch($label, $this->labels);
                 unset($this->labels[$key]);
-            } catch (\InvalidArgumentException $e) {
+            } catch (\OutOfBoundsException $e) {
                 continue;
             }
         }
@@ -541,7 +541,7 @@ class GitChangelog
      * @param   mixed  $value  [Optional] Value of option.
      *
      * @throws \OutOfBoundsException If the option you're trying to set is invalid.
-     * @throws \OutOfRangeException When setting option 'headTag' to an invalid value.
+     * @throws \RangeException When setting option 'headTag' to an invalid value.
      * @throws \DigiLive\GitChangelog\GitChangelogException If fetching the repository tags fails.
      * @see GitChangelog::$options
      * @see GitChangelog::fetchTags()
@@ -558,7 +558,7 @@ class GitChangelog
             }
 
             if ('headTagName' == $option && in_array($value, $this->fetchTags())) {
-                throw new \OutOfRangeException('Attempt to set option headTagName to an already existing tag value!');
+                throw new \RangeException('Attempt to set option headTagName to an already existing tag value!');
             }
 
             $this->options[$option] = $value;

--- a/src/GitChangelog.php
+++ b/src/GitChangelog.php
@@ -202,17 +202,20 @@ class GitChangelog
         }
 
         $this->gitTags = [];
-        $command       = [
-            $this->gitExecutable,
-            '--git-dir',
-            "$this->repoPath.git",
-            'tag',
-            '--sort',
-            "-{$this->options['tagOrderBy']}",
-        ];
 
         try {
-            $this->gitTags = $this->runCommand($command, true);
+            $this->gitTags = $this->runCommand(
+                [
+                    $this->gitExecutable,
+                    '--git-dir',
+                    "$this->repoPath.git",
+                    'tag',
+                    '--sort',
+                    "-{$this->options['tagOrderBy']}",
+                ],
+                true
+            );
+
             // Add HEAD revision as tag.
             if ($this->toTag === null) {
                 array_unshift($this->gitTags, $this->toTag);
@@ -269,8 +272,8 @@ class GitChangelog
         }
 
         // Re-fetch tags because tag range and order can be altered after pre-fetch.
-        $gitTags    = $this->fetchTags(true);
-        $commitData = [];
+        $gitTags       = $this->fetchTags(true);
+        $commitData    = [];
         $includeMerges = $this->options['includeMergeCommits'] ? null : '--no-merges';
 
         // Fetch dates and commit titles/hashes from git log for each tag.
@@ -279,38 +282,47 @@ class GitChangelog
             $tagRange   = false !== $rangeStart ? "$rangeStart..$tag" : "$tag";
 
             // Fetch tag dates.
-            $commitData[$tag]['date'] = $this->runCommand([
-                $this->gitExecutable,
-                '--git-dir',
-                "$this->repoPath.git",
-                'log',
-                '-1',
-                '--pretty=format:%ad',
-                '--date=short',
-                $tag,
-            ], false);
+            $commitData[$tag]['date'] = $this->runCommand(
+                [
+                    $this->gitExecutable,
+                    '--git-dir',
+                    "$this->repoPath.git",
+                    'log',
+                    '-1',
+                    '--pretty=format:%ad',
+                    '--date=short',
+                    $tag,
+                ],
+                false
+            );
 
             // Fetch commit titles.
-            $commitData[$tag]['titles'] = $this->runCommand([
-                $this->gitExecutable,
-                '--git-dir',
-                "$this->repoPath.git",
-                'log',
-                $tagRange,
-                '--pretty=format:%s',
-                $includeMerges,
-            ], true);
+            $commitData[$tag]['titles'] = $this->runCommand(
+                [
+                    $this->gitExecutable,
+                    '--git-dir',
+                    "$this->repoPath.git",
+                    'log',
+                    $tagRange,
+                    '--pretty=format:%s',
+                    $includeMerges,
+                ],
+                true
+            );
 
             // Fetch commit hashes.
-            $commitData[$tag]['hashes'] = $this->runCommand([
-                $this->gitExecutable,
-                '--git-dir',
-                "$this->repoPath.git",
-                'log',
-                $tagRange,
-                '--pretty=format:%h',
-                $includeMerges,
-            ], true);
+            $commitData[$tag]['hashes'] = $this->runCommand(
+                [
+                    $this->gitExecutable,
+                    '--git-dir',
+                    "$this->repoPath.git",
+                    'log',
+                    $tagRange,
+                    '--pretty=format:%h',
+                    $includeMerges,
+                ],
+                true
+            );
         }
 
         // Cache commit data and process it.
@@ -427,7 +439,7 @@ class GitChangelog
      *
      * @see GitChangelog::fetchTags()
      */
-    public function setToTag(string $tag = null): void
+    public function setToTag(?string $tag = null): void
     {
         $tag = $tag ?? '';
         Utilities::arraySearch($tag, $this->gitTags);
@@ -445,7 +457,7 @@ class GitChangelog
      *
      * @see GitChangelog::fetchTags()
      */
-    public function setFromTag(string $tag = null): void
+    public function setFromTag(?string $tag = null): void
     {
         if (null !== $tag) {
             Utilities::arraySearch($tag, $this->gitTags);

--- a/src/GitChangelogException.php
+++ b/src/GitChangelogException.php
@@ -45,4 +45,5 @@ namespace DigiLive\GitChangelog;
  */
 class GitChangelogException extends \Exception
 {
+    // Intentionally left blank because the class doesn't extend or alters the \Exception class.
 }

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -116,7 +116,7 @@ class Utilities
     {
         $key = array_search($value, $array, $strict);
         if (false === $key) {
-            throw new \OutOfBoundsException("Value $value, does not exist in array!");
+            throw new \OutOfBoundsException("Value $value does not exist in array!");
         }
 
         return $key;

--- a/tests/GitChangelogTest.php
+++ b/tests/GitChangelogTest.php
@@ -45,7 +45,6 @@ use Exception;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use ReflectionException;
 use stdClass;
 
 /**

--- a/tests/GitChangelogTest.php
+++ b/tests/GitChangelogTest.php
@@ -40,6 +40,7 @@ declare(strict_types=1);
 namespace DigiLive\GitChangelog\Tests;
 
 use DigiLive\GitChangelog\GitChangelog;
+use DigiLive\GitChangelog\GitChangelogException;
 use Exception;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
@@ -127,7 +128,7 @@ class GitChangelogTest extends TestCase
         $this->setPrivateProperty($changeLog, 'changelog', $dummyContent);
 
         // Test without base content.
-        $this->assertequals($dummyContent, $changeLog->get());
+        $this->assertequals($dummyContent, $changeLog->get(false));
 
         // Test with base content
         $changeLog->setBaseContent($dummyContent);
@@ -197,7 +198,7 @@ class GitChangelogTest extends TestCase
     {
         $changeLog = new GitChangelog();
 
-        $this->expectException('Error');
+        $this->expectException(\Error::class);
         /** @noinspection PhpParamsInspection */
         $changeLog->setLabels(new stdClass());
     }
@@ -236,7 +237,7 @@ class GitChangelogTest extends TestCase
         $this->assertNull($this->getPrivateProperty($changeLog, 'fromTag'));
 
         // Test exception.
-        $this->expectException('Exception');
+        $this->expectException(\OutOfBoundsException::class);
         $changeLog->setFromTag('DoesNotExist');
     }
 
@@ -298,7 +299,7 @@ class GitChangelogTest extends TestCase
         $this->assertSame('', $this->getPrivateProperty($changeLog, 'toTag'));
 
         // Test exception.
-        $this->expectException('Exception');
+        $this->expectException(\OutOfBoundsException::class);
         $changeLog->setToTag('DoesNotExist');
     }
 
@@ -347,7 +348,7 @@ class GitChangelogTest extends TestCase
     {
         $changeLog = new GitChangelog();
 
-        $this->expectException('RunTimeException');
+        $this->expectException(GitChangelogException::class);
         $changeLog->save('nonExistingPath/fileName');
     }
 
@@ -360,7 +361,7 @@ class GitChangelogTest extends TestCase
         $changeLog->save($filePath);
         chmod($filePath, 0000);
 
-        $this->expectException('RunTimeException');
+        $this->expectException(GitChangelogException::class);
         $changeLog->save(vfsStream::url('testFolder/changelog.md'));
     }
 
@@ -387,7 +388,7 @@ class GitChangelogTest extends TestCase
     {
         $changeLog = new GitChangelog();
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\OutOfBoundsException::class);
         $changeLog->setOptions('NotExistingOption', 'Test');
     }
 
@@ -396,7 +397,7 @@ class GitChangelogTest extends TestCase
         $changeLog = new GitChangelog();
         $this->setPrivateProperty($changeLog, 'gitTags', ['Test']);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\RangeException::class);
         $changeLog->setOptions('headTagName', 'Test');
     }
 }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -97,18 +97,18 @@ class HtmlTest extends TestCase
         foreach ($testValues as $key => $value) {
             $this->setPrivateProperty($changeLog, 'commitData', $value);
             $changeLog->build();
-            $this->assertEquals($expectedValues[$key], $changeLog->get());
+            $this->assertEquals($expectedValues[$key], $changeLog->get(false));
         }
 
         // Test formatting of issues and hashes.
         $changeLog->issueUrl  = '<Issue>{issue}</Issue>';
         $changeLog->commitUrl = '<Commit>{hash}</Commit>';
         $changeLog->build();
-        $this->assertEquals($expectedValues[5], $changeLog->get());
+        $this->assertEquals($expectedValues[5], $changeLog->get(false));
         // Disable hashes
         $changeLog->setOptions('addHashes', false);
         $changeLog->build();
-        $this->assertEquals($expectedValues[6], $changeLog->get());
+        $this->assertEquals($expectedValues[6], $changeLog->get(false));
     }
 
     /**
@@ -168,7 +168,7 @@ class HtmlTest extends TestCase
         foreach ($testValues as $key => $value) {
             $this->setPrivateProperty($changeLog, 'commitData', $value);
             $changeLog->build();
-            $this->assertEquals($expectedValues[$key], $changeLog->get());
+            $this->assertEquals($expectedValues[$key], $changeLog->get(false));
         }
     }
 }

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -38,7 +38,6 @@ namespace DigiLive\GitChangelog\Tests;
 use DigiLive\GitChangelog\Renderers\Html;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use ReflectionException;
 
 /**
  * Class HtmlTest

--- a/tests/MarkDownTest.php
+++ b/tests/MarkDownTest.php
@@ -38,7 +38,6 @@ namespace DigiLive\GitChangelog\Tests;
 use DigiLive\GitChangelog\Renderers\MarkDown;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use ReflectionException;
 
 /**
  * Class MarkDownTest

--- a/tests/MarkDownTest.php
+++ b/tests/MarkDownTest.php
@@ -75,7 +75,7 @@ class MarkDownTest extends TestCase
             ];
         $expectedValues =
             [
-                //No tags
+                // No tags
                 "# Changelog\n\nNo changes.\n",
                 // Head Revision included.
                 "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* C (E)\n* D (F)\n\n",
@@ -94,18 +94,18 @@ class MarkDownTest extends TestCase
         foreach ($testValues as $key => $value) {
             $this->setPrivateProperty($changeLog, 'commitData', $value);
             $changeLog->build();
-            $this->assertEquals($expectedValues[$key], $changeLog->get());
+            $this->assertEquals($expectedValues[$key], $changeLog->get(false));
         }
 
         // Test formatting of issues and hashes.
         $changeLog->issueUrl  = '<i>{issue}</i>';
         $changeLog->commitUrl = '<c>{hash}</c>';
         $changeLog->build();
-        $this->assertEquals($expectedValues[5], $changeLog->get());
+        $this->assertEquals($expectedValues[5], $changeLog->get(false));
         // Disable hashes
         $changeLog->setOptions('addHashes', false);
         $changeLog->build();
-        $this->assertEquals($expectedValues[6], $changeLog->get());
+        $this->assertEquals($expectedValues[6], $changeLog->get(false));
     }
 
     /**
@@ -151,7 +151,7 @@ class MarkDownTest extends TestCase
             ];
         $expectedValues =
             [
-                //No tags
+                // No tags
                 "# Changelog\n\nNo changes.\n",
                 // Head Revision included.
                 "# Changelog\n\n## Upcoming changes (Undetermined)\n\n* D (F)\n* C (E)\n\n",
@@ -164,7 +164,7 @@ class MarkDownTest extends TestCase
         foreach ($testValues as $key => $value) {
             $this->setPrivateProperty($changeLog, 'commitData', $value);
             $changeLog->build();
-            $this->assertEquals($expectedValues[$key], $changeLog->get());
+            $this->assertEquals($expectedValues[$key], $changeLog->get(false));
         }
     }
 }


### PR DESCRIPTION
Instead of calling functions exec and shell_exec, make use of the
symfony/process package.
The package will take care of the differences between operating system
and escaping arguments to prevent security issues.